### PR TITLE
Bump `enketo_core` dependency to 7.2.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "private": true,
     "license": "Apache-2.0",
     "dependencies": {
-        "enketo-core": "5.x.x"
+        "enketo-core": "7.2.3"
     }
 }


### PR DESCRIPTION
`enketo_core` has introduced new methods that are mandatory.
It fixes `e.globalInit is not a function` and `e.globalReset is not a function` errors.
