### PR TITLE
Update `enketo-core` dependency to 8.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "private": true,
     "license": "Apache-2.0",
     "dependencies": {
-        "enketo-core": "8.2.0"
+        "enketo-core": "8.3.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
     "private": true,
     "license": "Apache-2.0",
     "dependencies": {
-        "enketo-core": "7.2.3"
+        "enketo-core": "8.2.0"
     }
 }


### PR DESCRIPTION
Resolve the node incompatibility with `enketo-core v7.2.3` which required node versions to be ">=14 <17". This upgrade supports `node v20.12.2` is now compatible with the new [release](https://github.com/enketo/enketo/) of `enketo v7.3.1`.